### PR TITLE
WASM-Bigint is no longer experimental, so we can/have to omit the flag.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "ts-node-dev --experimental-wasi-unstable-preview1 --experimental-wasm-bigint --project ./server/tsconfig.json --respawn  ./server/index.ts",
     "start": "tsc --project ./server/tsconfig.json",
-    "poststart": "node ./dist/index.js"
+    "poststart": "node --experimental-wasi-unstable-preview1  ./dist/index.js"
   },
   "engines": {
     "node": ">=12.18.1"


### PR DESCRIPTION
WASM-Bigint is no longer experimental, so we can/have to omit the flag.
Otherwise the poststart stuff wont run on newer nodejs versions.



(Ignore the first commit, wasi is actually still experimental, so the flag is still required)